### PR TITLE
Update repository URL allowing override and bump to 0.11.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.8
 
-ARG LUTIM_VERSION=0.11.4
+ARG LUTIM_VERSION=0.11.5
+ARG LUTIM_REPO=https://framagit.org/fiat-tux/hat-softwares/lutim.git
 
 ENV GID=991 \
     UID=991 \
@@ -12,9 +13,9 @@ ENV GID=991 \
     MAX_DELAY=0
 
 LABEL description="lutim based on alpine" \
-      tags="latest 0.11.4 0.11 0" \
+      tags="latest 0.11.5 0.11.4 0.11 0" \
       maintainer="xataz <https://github.com/xataz>" \
-      build_ver="201812081200"
+      build_ver="201905111800"
 
 RUN apk add --update --no-cache --virtual .build-deps \
                 build-base \
@@ -45,7 +46,7 @@ RUN apk add --update --no-cache --virtual .build-deps \
                 postgresql-libs \
     && echo | cpan \
     && cpan install Carton \
-    && git clone -b ${LUTIM_VERSION} https://framagit.org/luc/lutim.git /usr/lutim \
+    && git clone -b ${LUTIM_VERSION} ${LUTIM_REPO} /usr/lutim \
     && cd /usr/lutim \
     && echo "requires 'Image::Magick';" >> /usr/lutim/cpanfile \
     && echo "requires 'Mojolicious::Plugin::AssetPack::Backcompat';" >> /usr/lutim/cpanfile \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 > If you don't trust, you can build yourself.
 
 ## Tag available
-* latest, 0.11.4, 0.11, 0 [(Dockerfile)](https://github.com/xataz/docker-lutim/blob/master/Dockerfile)
+* latest, 0.11.5, 0.11.4, 0.11, 0 [(Dockerfile)](https://github.com/xataz/docker-lutim/blob/master/Dockerfile)
 
 ## Description
 What is [Lutim](https://framagit.org/luc/lutim) ?


### PR DESCRIPTION
- Update the repository URL to it's newest home
- Allow overriding of the repository URL
- Bump Lutim to version 0.11.5

@xataz How does the `LABEL`ing work? Do you update those values after drone has built the image?